### PR TITLE
Implement Topics API

### DIFF
--- a/backend/app/Http/Controllers/TopicController.php
+++ b/backend/app/Http/Controllers/TopicController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Topic;
+use Illuminate\Http\Request;
+use App\Http\Resources\TopicCollection;
+
+class TopicController extends Controller
+{
+    public function index(Request $request)
+    {
+        $this->validate($request, [
+            'category' => 'sometimes|string',
+            'page' => 'sometimes|integer|min:1',
+            'per_page' => 'sometimes|integer|min:1|max:100',
+        ]);
+
+        $query = Topic::query();
+
+        if ($request->filled('category')) {
+            $query->where('category', $request->get('category'));
+        }
+
+        $perPage = $request->get('per_page', 15);
+        $topics = $query->orderByDesc('published_at')->paginate($perPage);
+
+        return new TopicCollection($topics);
+    }
+}

--- a/backend/app/Http/Resources/TopicCollection.php
+++ b/backend/app/Http/Resources/TopicCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class TopicCollection extends ResourceCollection
+{
+    public function toArray($request)
+    {
+        return [
+            'topics' => TopicResource::collection($this->collection),
+            'meta' => [
+                'current_page' => $this->currentPage(),
+                'per_page' => $this->perPage(),
+                'total' => $this->total(),
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/TopicResource.php
+++ b/backend/app/Http/Resources/TopicResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TopicResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'url' => $this->url,
+            'published_at' => optional($this->published_at)->toAtomString(),
+        ];
+    }
+}

--- a/backend/app/Models/Topic.php
+++ b/backend/app/Models/Topic.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Topic extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['title', 'url', 'category', 'published_at'];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+}

--- a/backend/database/factories/TopicFactory.php
+++ b/backend/database/factories/TopicFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Topic;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TopicFactory extends Factory
+{
+    protected $model = Topic::class;
+
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence,
+            'url' => $this->faker->url,
+            'category' => $this->faker->word,
+            'published_at' => $this->faker->dateTime,
+        ];
+    }
+}

--- a/backend/database/migrations/2025_07_04_000000_create_topics_table.php
+++ b/backend/database/migrations/2025_07_04_000000_create_topics_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('topics', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('url');
+            $table->string('category')->index();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('topics');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,8 +2,11 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HabitController;
+use App\Http\Controllers\TopicController;
 
 Route::get('/habits', [HabitController::class, 'index']);
 Route::post('/habits', [HabitController::class, 'store']);
 Route::delete('/habits/{habit}', [HabitController::class, 'destroy']);
 Route::patch('/habits/{habit}/toggle', [HabitController::class, 'toggle']);
+
+Route::get('/api/v1/topics', [TopicController::class, 'index']);

--- a/backend/tests/TopicApiTest.php
+++ b/backend/tests/TopicApiTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests;
+
+use App\Models\Topic;
+use Laravel\Lumen\Testing\DatabaseMigrations;
+
+class TopicApiTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function test_topics_index_returns_paginated_list()
+    {
+        Topic::factory()->count(3)->create();
+
+        $this->get('/api/v1/topics');
+        $this->seeStatusCode(200);
+        $this->seeJsonStructure([
+            'topics' => [
+                '*' => ['id', 'title', 'url', 'published_at'],
+            ],
+            'meta' => ['current_page', 'per_page', 'total'],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for `topics` table
- create `Topic` model with factory
- build `TopicController` with filtering and pagination
- serialize topics with resource/collection classes
- wire up `/api/v1/topics` route
- test Topics API structure

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686b67a759188330bd3ffd60d44f246f